### PR TITLE
Fix for Codeplex issue 21973

### DIFF
--- a/DotNetProjects.Wpf.Extended.Toolkit.sln
+++ b/DotNetProjects.Wpf.Extended.Toolkit.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+# Visual Studio 2013
+VisualStudioVersion = 12.0.30723.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xceed.Wpf.Toolkit.LiveExplorer", "Src\Xceed.Wpf.Toolkit.LiveExplorer\Xceed.Wpf.Toolkit.LiveExplorer.csproj", "{5E7DC9C8-3E27-400C-B84C-29FF9E710CB3}"
 EndProject
@@ -18,6 +18,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xceed.Wpf.AvalonDock.Themes.Metro", "Src\Xceed.Wpf.AvalonDock.Themes.Metro\Xceed.Wpf.AvalonDock.Themes.Metro.csproj", "{89286EB4-B4A1-418C-839A-067B00F442D8}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xceed.Wpf.AvalonDock.Themes.Aero", "Src\Xceed.Wpf.AvalonDock.Themes.Aero\Xceed.Wpf.AvalonDock.Themes.Aero.csproj", "{BA72CCE0-A9FB-4995-B496-7FEC5C87B85B}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1A9D635D-9DA8-4EFC-8BEF-53478FB5E266}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Src/Xceed.Wpf.Toolkit/NumericUpDown/Implementation/CommonNumericUpDown.cs
+++ b/Src/Xceed.Wpf.Toolkit/NumericUpDown/Implementation/CommonNumericUpDown.cs
@@ -184,7 +184,7 @@ namespace Xceed.Wpf.Toolkit
         return this.Value;
 
       //Don't know why someone would format a T as %, but just in case they do.
-      result = this.ContainsLetterForPercent( this.FormatString )
+      result = this.IsPercent(this.FormatString)
         ? _fromDecimal( ParsePercent( text, CultureInfo ) )
         : _fromText( text, this.ParsingNumberStyle, CultureInfo );
 
@@ -227,21 +227,22 @@ namespace Xceed.Wpf.Toolkit
         Spinner.ValidSpinDirection = validDirections;
     }
 
-    private bool ContainsLetterForPercent( string stringToTest )
+    private bool IsPercent(string stringToTest)
     {
-      int PIndex = stringToTest.IndexOf( "P" );
-      if( PIndex > 0 )
-      {
-        //stringToTest contains a "P" between 2 "'", it's not considered as percent
-        return !( stringToTest.Substring( 0, PIndex ).Contains( "'" )
-                && stringToTest.Substring( PIndex, FormatString.Length - PIndex ).Contains( "'" ) );
-      }
-      return false;
+        int PIndex = stringToTest.IndexOf("P");
+        if (PIndex >= 0)
+        {
+            bool isText = (stringToTest.Substring(0, PIndex).Contains("'")
+                          && stringToTest.Substring(PIndex, FormatString.Length - PIndex).Contains("'"));
+
+            return !isText;
+        }
+        return false;
     }
 
     private T? GetClippedMinMaxValue()
     {
-      T? result = this.ContainsLetterForPercent( this.FormatString )
+        T? result = this.IsPercent(this.FormatString)
                 ? _fromDecimal( ParsePercent( this.Text, CultureInfo ) )
                 : _fromText( this.Text, this.ParsingNumberStyle, CultureInfo );
 


### PR DESCRIPTION
Xceed introduced an issue with the NumericUpDown controls when using FormatString="P". This pull request contains the suggested fix (tested and shown to be working).

Issue can be found here: https://wpftoolkit.codeplex.com/workitem/21973