### PR TITLE
Fix the disposing of WindowHookHandler so that it gets always cleaned

### DIFF
--- a/Src/Xceed.Wpf.AvalonDock/Controls/FocusElementManager.cs
+++ b/Src/Xceed.Wpf.AvalonDock/Controls/FocusElementManager.cs
@@ -41,10 +41,11 @@ namespace Xceed.Wpf.AvalonDock.Controls
                 _windowHandler = new WindowHookHandler();
                 _windowHandler.FocusChanged += new EventHandler<FocusChangeEventArgs>(WindowFocusChanging);
                 //_windowHandler.Activate += new EventHandler<WindowActivateEventArgs>(WindowActivating);
-                _windowHandler.Attach();
 
                 if (Application.Current != null)
-                    Application.Current.Exit += new ExitEventHandler(Current_Exit);
+                    Application.Current.Exit += Current_Exit;
+                else
+                    AppDomain.CurrentDomain.ProcessExit += Current_Exit;
             }
 
             manager.PreviewGotKeyboardFocus += new KeyboardFocusChangedEventHandler(manager_PreviewGotKeyboardFocus);
@@ -71,9 +72,10 @@ namespace Xceed.Wpf.AvalonDock.Controls
 
         }
 
-        private static void Current_Exit(object sender, ExitEventArgs e)
+        private static void Current_Exit(object sender, EventArgs e)
         {
-            Application.Current.Exit -= new ExitEventHandler(Current_Exit);
+            AppDomain.CurrentDomain.ProcessExit -= Current_Exit;
+
             if (_windowHandler != null)
             {
                 _windowHandler.FocusChanged -= new EventHandler<FocusChangeEventArgs>(WindowFocusChanging);

--- a/Src/Xceed.Wpf.AvalonDock/Controls/WindowHookHandler.cs
+++ b/Src/Xceed.Wpf.AvalonDock/Controls/WindowHookHandler.cs
@@ -42,16 +42,35 @@ namespace Xceed.Wpf.AvalonDock.Controls
         }
     }
 
-    class WindowHookHandler
+    class WindowHookHandler : IDisposable
     {
         public WindowHookHandler()
         { 
+            Attach();
+        }
 
+        ~WindowHookHandler()
+        {
+            Dispose(disposing:false);
+        }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                GC.SuppressFinalize(this);
+            }
+            Detach();
         }
 
         IntPtr _windowHook;
         Win32Helper.HookProc _hookProc;
-        public void Attach()
+        private void Attach()
         {
             _hookProc = new Win32Helper.HookProc(this.HookProc);
             _windowHook = Win32Helper.SetWindowsHookEx(


### PR DESCRIPTION
Previously this was causing different crash with hard to reproduce callstacks when the application was closing