### PR TITLE
Fix messagebox icons not appearing due to assemblyname change

### DIFF
--- a/Src/Xceed.Wpf.Toolkit/MessageBox/Implementation/MessageBox.cs
+++ b/Src/Xceed.Wpf.Toolkit/MessageBox/Implementation/MessageBox.cs
@@ -932,7 +932,7 @@ namespace Xceed.Wpf.Toolkit
       }
 
       // Use this syntax for other themes to get the icons
-      this.ImageSource = new BitmapImage( new Uri( String.Format( "/Xceed.Wpf.Toolkit;component/MessageBox/Icons/{0}", iconName ), UriKind.RelativeOrAbsolute ) );
+      this.ImageSource = new BitmapImage( new Uri( String.Format( "/DotNetProjects.Wpf.Extended.Toolkit;component/MessageBox/Icons/{0}", iconName ), UriKind.RelativeOrAbsolute ) );
     }
 
     /// <summary>


### PR DESCRIPTION
This fixes the URI used when looking up the messagebox icons to point to the new DotNetProjects.Wpf.Extended.Toolkit assemblyname. It pointed to the old assemblyname, which made lookup fail.