### PR TITLE
Alter UpDownBase to be inline with Master. Now derived controls (e.g.…

### DIFF
--- a/Src/Xceed.Wpf.Toolkit/Primitives/UpDownBase.cs
+++ b/Src/Xceed.Wpf.Toolkit/Primitives/UpDownBase.cs
@@ -755,11 +755,8 @@ RoutedPropertyChangedEventHandler<object> ), typeof( UpDownBase<T> ) );
         {
           if( string.IsNullOrEmpty( text ) )
           {
-            if (!typeof(T).IsClass && Nullable.GetUnderlyingType(typeof(T)) == null)
-            {
-              // An empty input sets the value to the default value.
-              this.SetValueInternal( this.DefaultValue );
-            }
+            // An empty input sets the value to the default value.
+            this.SetValueInternal( this.DefaultValue );
           }
           else
           {


### PR DESCRIPTION
… NumericUpDown, DateTimePicker, etc.) will allow null inputs.