### PR TITLE
Fix munged color names

### DIFF
--- a/Src/Xceed.Wpf.Toolkit/Core/Utilities/ColorUtilities.cs
+++ b/Src/Xceed.Wpf.Toolkit/Core/Utilities/ColorUtilities.cs
@@ -39,7 +39,7 @@ namespace Xceed.Wpf.Toolkit.Core.Utilities
 
     public static string FormatColorString( string stringToFormat, bool isUsingAlphaChannel )
     {
-      if( !isUsingAlphaChannel && ( stringToFormat.Length == 9 ) )
+      if( !isUsingAlphaChannel && ( stringToFormat.Length == 9 ) && ( stringToFormat[0] == '#' ) )
         return stringToFormat.Remove( 1, 2 );
       return stringToFormat;
     }


### PR DESCRIPTION
The bug changed `OrangeRed` to `OngeRed` and `Gainsboro` to `Gnsboro`, for example.

In our app that uses the ColorPicker, the color name shows up fine when first selected, but shows as munged when the color is set to OrangeRed programmatically.  So showing the screen a second time when OrangeRed was selected would reveal the bug.

![OngeRed](https://user-images.githubusercontent.com/1396319/100125295-3c573700-2e42-11eb-9c44-3fc2483d0701.png)
