### PR TITLE
Fixed zoombox scrollbars not having the proper size at startup.

### DIFF
--- a/Src/Xceed.Wpf.Toolkit/Zoombox/Zoombox.cs
+++ b/Src/Xceed.Wpf.Toolkit/Zoombox/Zoombox.cs
@@ -3090,9 +3090,17 @@ namespace Xceed.Wpf.Toolkit.Zoombox
             else if( this.IsUsingScrollBars )
             {
               //Vertical scrollBar
+              if (_verticalScrollBar.ViewportSize == 0)
+              {
+                _verticalScrollBar.ViewportSize = this.RenderSize.Height;
+              }
               _verticalScrollBar.Maximum = scaledContentSize.Height - _verticalScrollBar.ViewportSize;
               _verticalScrollBar.Value = -newRelativePosition.Y;
               //Horizontal scrollBar
+              if (_horizontalScrollBar.ViewportSize == 0)
+              {
+                _horizontalScrollBar.ViewportSize = this.RenderSize.Width;
+              }
               _horizontalScrollBar.Maximum = scaledContentSize.Width - _horizontalScrollBar.ViewportSize;
               _horizontalScrollBar.Value = -newRelativePosition.X;
             }


### PR DESCRIPTION
With the example below, we we're having issues that initially the scrollbars we're not fully useable, you cannot scroll towards eithers end. This happens because the `UpdateView` method is called before the SetScrollbars method because of the ViewStack. This fix makes sure the ViewPortSize is set properly - it is not the nicest fix as I'm not really deep into the codebase.

```
<Window x:Class="WpfApp1.MainWindow"
        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
        xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
        xmlns:local="clr-namespace:WpfApp1"
        mc:Ignorable="d"
        Title="MainWindow" Height="720" Width="1280">
    <Grid>
        <xctk:Zoombox
            IsUsingScrollBars="True"
            MinScale="0.5"
            MaxScale="100"
            Scale="1"
            Background="Black"
            x:Name="Zoombox"
            KeepContentInBounds="True">
            <Grid Width="2000" Height="2000" Background="Aqua" />
        </xctk:Zoombox>
    </Grid>
</Window>
 ```