### PR TITLE
Fix Datetime Picker bug which does not take into account the time if the the previous date was null

### DIFF
--- a/Src/Xceed.Wpf.Toolkit/DateTimePicker/Implementation/DateTimePicker.cs
+++ b/Src/Xceed.Wpf.Toolkit/DateTimePicker/Implementation/DateTimePicker.cs
@@ -287,14 +287,14 @@ namespace Xceed.Wpf.Toolkit
     protected override void OnValueChanged( DateTime? oldValue, DateTime? newValue )
     {
       //The calendar only select the Date part, not the time part.
-      DateTime? newValueDate = (newValue != null) 
-        ? newValue.Value.Date 
-        : (DateTime?)null;
+      //Pull request : the time part is important if we want to initialise the calendar with the current day and another hour 
+      DateTime? newValueDate = (newValue != null)  ? newValue.Value : (DateTime?)null;
 
       if( _calendar != null && _calendar.SelectedDate != newValueDate)
       {
         _calendar.SelectedDate = newValueDate;
         _calendar.DisplayDate = newValue.GetValueOrDefault( this.ContextNow );
+
       }
 
       //If we change any part of the datetime without
@@ -406,16 +406,17 @@ namespace Xceed.Wpf.Toolkit
             newDate = newDate.Value.Date + _calendarIntendedDateTime.Value.TimeOfDay;
             _calendarTemporaryDateTime = null;
             _calendarIntendedDateTime = null;
-          }
-          else if( ( _timePicker != null ) && _timePicker.TempValue.HasValue )
-          {
-            newDate = newDate.Value.Date + _timePicker.TempValue.Value.TimeOfDay;
-          }
+          } 
+        //Pull request : the value should be used first. The Tempvalue should be a fallback 
           else if( Value != null )
           {
             newDate = newDate.Value.Date + Value.Value.TimeOfDay;
           }
-
+          else if( ( _timePicker != null ) && _timePicker.TempValue.HasValue ) // bug
+          {
+            newDate = newDate.Value.Date + _timePicker.TempValue.Value.TimeOfDay;
+          }
+        
           // Always be sure that the time part of the selected value is always 
           // within the bound of the min max. The time part could be altered
           // if the calendar's selected date match the Minimum or Maximum date.


### PR DESCRIPTION
There is a bug In the current implementation of the dateTimePicker.Cs where you cannot chose a current day datetime with another hour. The hour will be automatically replace by the current one. This pull request correct this bug 

