### PR TITLE
Fix automatic creation of columns

### DIFF
--- a/Src/Xceed.Wpf.DataGrid/ItemsSourceHelper.cs
+++ b/Src/Xceed.Wpf.DataGrid/ItemsSourceHelper.cs
@@ -584,7 +584,7 @@ namespace Xceed.Wpf.DataGrid
       var propertyDescription = propertyDescriptionRoute.Current;
       var dataType = propertyDescription.DataType;
 
-      if( !propertyDescription.IsBrowsable || !propertyDescription.IsDisplayable )
+      if( !propertyDescription.IsBrowsable )
         return null;
 
       for( var current = propertyDescriptionRoute; current != null; current = current.Parent )


### PR DESCRIPTION
- Removed check for "IsDisplayable" during column creation

The original logic before the version 3.3 merge does not appear to have checked "IsDisplayable" during column creation.
It appears this flag can toggled based on the actual visibility of the column and should not be used to determine whether the column is created.
Newer logic also added during this version creates descriptions with displayable set to "false" by default.
With this check in place some columns may not be created when the control is initialized with automatic creation enabled.
