### PR TITLE
Add ButtonWidth property to ButtonSpinner & NumericUpDowns

### DIFF
--- a/Src/Xceed.Wpf.Toolkit.LiveExplorer/Samples/Numeric/Views/NumericView.xaml
+++ b/Src/Xceed.Wpf.Toolkit.LiveExplorer/Samples/Numeric/Views/NumericView.xaml
@@ -295,6 +295,20 @@
                               HorizontalAlignment="Stretch"
                               Margin="5" />
 
+          <TextBlock Grid.Column="2"
+                     Grid.Row="6"
+                     Text="Button Width"
+                     VerticalAlignment="Center"
+                     Margin="10,0,0,0"/>
+          <xctk:DoubleUpDown Grid.Column="3"
+                             Grid.Row="6"
+                             Minimum="0.0"
+                             VerticalAlignment="Center"
+                             HorizontalAlignment="Stretch"
+                             FormatString="F1"
+                             Value="{Binding ButtonWidth, ElementName=_doubleUpDown}"
+                             Margin="5"/>
+
           <!-- 3rd column -->
           <TextBlock Grid.Column="4"
                      Text="ButtonSpinnerLocation:"

--- a/Src/Xceed.Wpf.Toolkit/ButtonSpinner/Implementation/ButtonSpinner.cs
+++ b/Src/Xceed.Wpf.Toolkit/ButtonSpinner/Implementation/ButtonSpinner.cs
@@ -81,6 +81,17 @@ namespace Xceed.Wpf.Toolkit
 
     #endregion //ButtonSpinnerLocation
 
+    #region ButtonWidth
+    public double ButtonWidth
+    {
+      get { return (double)GetValue(ButtonWidthProperty); }
+      set { SetValue(ButtonWidthProperty, value); }
+    }
+    public static readonly DependencyProperty ButtonWidthProperty =
+        DependencyProperty.Register("ButtonWidth", typeof(double), typeof(ButtonSpinner), 
+          new UIPropertyMetadata(SystemParameters.VerticalScrollBarWidth));
+    #endregion //ButtonWidth
+
     #region Content
 
     /// <summary>

--- a/Src/Xceed.Wpf.Toolkit/ButtonSpinner/Themes/Aero2.NormalColor.xaml
+++ b/Src/Xceed.Wpf.Toolkit/ButtonSpinner/Themes/Aero2.NormalColor.xaml
@@ -91,7 +91,7 @@
                               Style="{DynamicResource {x:Static themes:ResourceKeys.SpinnerButtonStyleKey}}"
                               IsTabStop="{TemplateBinding IsTabStop}"
                               ContentTemplate="{StaticResource IncreaseGlyphNormalKey}"
-                              Width="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}">
+                              Width="{TemplateBinding ButtonWidth}">
                 </RepeatButton>
 
               <RepeatButton x:Name="PART_DecreaseButton"
@@ -100,7 +100,7 @@
                               Style="{DynamicResource {x:Static themes:ResourceKeys.SpinnerButtonStyleKey}}"
                               IsTabStop="{TemplateBinding IsTabStop}"
                               ContentTemplate="{StaticResource DecreaseGlyphNormalKey}"
-                              Width="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}">
+                              Width="{TemplateBinding ButtonWidth}">
               </RepeatButton>
             </Grid>
           </Border>

--- a/Src/Xceed.Wpf.Toolkit/ButtonSpinner/Themes/Generic.xaml
+++ b/Src/Xceed.Wpf.Toolkit/ButtonSpinner/Themes/Generic.xaml
@@ -88,7 +88,7 @@
                               Style="{DynamicResource {x:Static themes:ResourceKeys.SpinnerButtonStyleKey}}"
                               IsTabStop="{TemplateBinding IsTabStop}"
                               ContentTemplate="{StaticResource IncreaseGlyphNormalKey}"
-                              Width="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}">
+                              Width="{TemplateBinding ButtonWidth}">
                 </RepeatButton>
 
                 <RepeatButton x:Name="PART_DecreaseButton"
@@ -97,7 +97,7 @@
                               Style="{DynamicResource {x:Static themes:ResourceKeys.SpinnerButtonStyleKey}}"
                               IsTabStop="{TemplateBinding IsTabStop}"
                               ContentTemplate="{StaticResource DecreaseGlyphNormalKey}"
-                              Width="{DynamicResource {x:Static SystemParameters.VerticalScrollBarWidthKey}}">
+                              Width="{TemplateBinding ButtonWidth}">
                 </RepeatButton>
               </Grid>
           </Border>

--- a/Src/Xceed.Wpf.Toolkit/NumericUpDown/Themes/Aero2.NormalColor.xaml
+++ b/Src/Xceed.Wpf.Toolkit/NumericUpDown/Themes/Aero2.NormalColor.xaml
@@ -62,7 +62,8 @@
                                VerticalContentAlignment="Stretch"
                                AllowSpin="{Binding AllowSpin, RelativeSource={RelativeSource TemplatedParent}}"
                                ShowButtonSpinner="{Binding ShowButtonSpinner, RelativeSource={RelativeSource TemplatedParent}}"
-                               ButtonSpinnerLocation="{Binding ButtonSpinnerLocation, RelativeSource={RelativeSource TemplatedParent}}">
+                               ButtonSpinnerLocation="{Binding ButtonSpinnerLocation, RelativeSource={RelativeSource TemplatedParent}}"
+                               ButtonWidth="{Binding ButtonWidth, RelativeSource={RelativeSource TemplatedParent}}">
             <local:WatermarkTextBox x:Name="PART_TextBox"
                                     BorderThickness="0"
                                     Background="Transparent"

--- a/Src/Xceed.Wpf.Toolkit/NumericUpDown/Themes/Generic.xaml
+++ b/Src/Xceed.Wpf.Toolkit/NumericUpDown/Themes/Generic.xaml
@@ -62,7 +62,8 @@
                                VerticalContentAlignment="Stretch"
                                AllowSpin="{Binding AllowSpin, RelativeSource={RelativeSource TemplatedParent}}"
                                ShowButtonSpinner="{Binding ShowButtonSpinner, RelativeSource={RelativeSource TemplatedParent}}"
-                               ButtonSpinnerLocation="{Binding ButtonSpinnerLocation, RelativeSource={RelativeSource TemplatedParent}}">
+                               ButtonSpinnerLocation="{Binding ButtonSpinnerLocation, RelativeSource={RelativeSource TemplatedParent}}"
+                               ButtonWidth="{Binding ButtonWidth, RelativeSource={RelativeSource TemplatedParent}}">
             <local:WatermarkTextBox x:Name="PART_TextBox"
                                     BorderThickness="0"
                                     Background="Transparent"

--- a/Src/Xceed.Wpf.Toolkit/Primitives/UpDownBase.cs
+++ b/Src/Xceed.Wpf.Toolkit/Primitives/UpDownBase.cs
@@ -103,6 +103,17 @@ new UIPropertyMetadata( true ) );
 
     #endregion //ButtonSpinnerLocation
 
+    #region ButtonWidth
+    public double ButtonWidth
+    {
+      get { return (double)GetValue(ButtonWidthProperty); }
+      set { SetValue(ButtonWidthProperty, value); }
+    }
+    public static readonly DependencyProperty ButtonWidthProperty =
+        DependencyProperty.Register("ButtonWidth", typeof(double), typeof(UpDownBase<T>), 
+            new UIPropertyMetadata(SystemParameters.VerticalScrollBarWidth));
+    #endregion //ButtonWidth
+
     #region ClipValueToMinMax
 
     public static readonly DependencyProperty ClipValueToMinMaxProperty = DependencyProperty.Register( "ClipValueToMinMax", typeof( bool ), typeof(


### PR DESCRIPTION
Add ability to change the width of the buttons in a ButtonSpinner and NumericUpDown. Ability to have wider (bigger) buttons is especially useful in touch screen applications.

Maintain the default value of the button width equal to SystemParameters.VerticalScrollBarWidth.

Add button width control to the NumericView sample.