### PR TITLE
Fixed Issue 56

### DIFF
--- a/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/PropertyGrid.cs
+++ b/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/PropertyGrid.cs
@@ -1181,6 +1181,8 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
 
 
       objectContainerHelper = new ObjectContainerHelper( this, SelectedObject );
+      // Reassign the backed up childrenItemsControl.
+      objectContainerHelper.ChildrenItemsControl = childrenItemsControl;
       objectContainerHelper.ObjectsGenerated += this.ObjectContainerHelper_ObjectsGenerated;
       objectContainerHelper.GenerateProperties();
     }


### PR DESCRIPTION
Closes https://github.com/dotnetprojects/WpfExtendedToolkit/issues/56

Fixed a NullReferenceException in PropertyGrid that occurred when assigning a value to the PropertyItem.CategoryOrder property in versions prior to 5.0.109.

In PropertyGrid.UpdateContainerHelper, the previous value of ChildrenItemsControl is stored:

```
  // Keep a backup of the template element and initialize the
  // new helper with it.
  ItemsControl childrenItemsControl = ( _containerHelper != null ) ? _containerHelper.ChildrenItemsControl : null;
```

However, once a new ObjectContainerHelper has been created, this value is not used. As a result, ChildrenItemsControl remains null, which later leads to a NullReferenceException in method ObjectContainerHelperBase.OnChildrenPropertyChanged.

Restored the missing assignment `objectContainerHelper.ChildrenItemsControl = childrenItemsControl`